### PR TITLE
Added values from Linux sysinfo() syscall

### DIFF
--- a/cetch.c
+++ b/cetch.c
@@ -69,6 +69,21 @@ int main(int argc, char *argv[])
     char *osrelease = utsname.release;
     if (!osrelease) osrelease = "unknown";
 
+#if defined __linux__
+#include <sys/sysinfo.h>
+#include <math.h>
+	struct sysinfo info;
+	sysinfo(&info);
+	long uptime_s = info.uptime;
+	char uptime[9];
+	snprintf(uptime, 9, "%.2d:%.2d:%.2d", uptime_s/3600,
+		uptime_s%3600/60, uptime_s%60);
+//	procs includes threads
+	short procs = info.procs;
+	double freeram = info.freeram/pow(1024,2);
+	double totalram = info.totalram/pow(1024,2);
+#endif
+
 #include "config.h"
     
     return 0;

--- a/config.def.h
+++ b/config.def.h
@@ -21,7 +21,11 @@ Variables:
     libversion  system libc version
     os		the system's uname
     osrelease	the system's uname release number
-    
+Linux only:
+	procs	running processes
+	freeram	free system memory in MiB
+	totalram	total system memory in MiB
+	uptime	system uptime
 **/
 
 // logo(os); [DEPRECATED]
@@ -31,3 +35,7 @@ item(BOLD GREEN "name" BOLD BLACK "%14s", gecos)
 item(BOLD YELLOW "libc" BOLD BLACK "%14s", lib)
 item(BOLD RED "os" BOLD BLACK "%16s", os)
 item(BOLD MAGENTA "shell" BOLD BLACK "%13s", shell)
+//item(BOLD BLUE "memory" BOLD BLACK "%8.4g MiB", totalram)
+//item(BOLD GREEN "uptime" BOLD BLACK "%12s", uptime)
+//item(BOLD YELLOW "processes" BOLD BLACK "%9d", procs)
+


### PR DESCRIPTION
Hi, I added some values for Linux, the examples are commented out by default in config.def.h since they aren't portable.